### PR TITLE
Fixed spawn bug hardcoding spawn z to 0

### DIFF
--- a/src/scenic/simulators/carla/simulator.py
+++ b/src/scenic/simulators/carla/simulator.py
@@ -86,7 +86,7 @@ class CarlaSimulation(DrivingSimulation):
 			print("blueprint: ", blueprint)
 
 			# Set up transform
-			loc = utils.scenicToCarlaLocation(obj.position, z=obj.elevation, world=self.world)
+			loc = utils.scenicToCarlaLocation(obj.position, world=self.world)
 			rot = utils.scenicToCarlaRotation(obj.heading)
 			transform = carla.Transform(loc, rot)
 			transform.location.z += obj.elevation

--- a/src/scenic/simulators/carla/utils/utils.py
+++ b/src/scenic/simulators/carla/utils/utils.py
@@ -9,7 +9,7 @@ from scenic.core.geometry import normalizeAngle
 def snapToGround(world, location):
 	"""Mutates @location to have the same z-coordinate as the nearest waypoint in @world."""
 	waypoint = world.get_map().get_waypoint(location)
-	return location
+	return waypoint.transform.location
 
 
 def scenicToCarlaVector3D(x, y, z=0.0):


### PR DESCRIPTION
Fixed a couple bugs related to the actor spawning:
- Fixed *snapToGround*, which wasn't returning the location of the calculated waypoint
- Removed the z input at *scenicToCarlaLocation*, as it was already being added two lines below, causing the elevation to be added twice