### PR TITLE
Dynamic crossing speed

### DIFF
--- a/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
@@ -14,19 +14,15 @@ model scenic.simulators.carla.model
 EGO_MODEL = "vehicle.lincoln.mkz2017"
 EGO_SPEED = 10
 
-PEDESTRIAN_SPEED = 5
-
-THRESHOLD = 15
+PEDESTRIAN_MIN_SPEED = 0.3
+THRESHOLD = 17
 
 # EGO BEHAVIOR: Follow lane and brake when reaches threshold distance to obstacle
 behavior EgoBehavior(speed=10):
     do FollowLaneBehavior(speed)
 
-behavior PedestrianBehavior(speed=3):
-    while (distance from self to ego) > THRESHOLD:
-        wait
-
-    do WalkForwardBehavior(speed)
+behavior PedestrianBehavior(min_speed=1, threshold=10):
+    do CrossingBehavior(ego, min_speed, threshold)
 
 ## DEFINING SPATIAL RELATIONS
 # Please refer to scenic/domains/driving/roads.py how to access detailed road infrastructure
@@ -41,7 +37,7 @@ vending_spot = OrientedPoint following roadDirection from spot for -3
 pedestrian = Pedestrian right of spot by 3,
     with heading 90 deg relative to spot.heading,
     with regionContainedIn None,
-    with behavior PedestrianBehavior(PEDESTRIAN_SPEED)
+    with behavior PedestrianBehavior(PEDESTRIAN_MIN_SPEED, THRESHOLD)
 
 vending_machine = VendingMachine right of vending_spot by 3,
     with heading -90 deg relative to vending_spot.heading,
@@ -52,3 +48,4 @@ ego = Car following roadDirection from spot for Range(-30, -20),
     with behavior EgoBehavior(EGO_SPEED)
 
 require (distance from ego to intersection) > 20
+terminate when (distance to spot) > 50

--- a/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge3_dynamic.scenic
@@ -14,7 +14,7 @@ model scenic.simulators.carla.model
 EGO_MODEL = "vehicle.lincoln.mkz2017"
 EGO_SPEED = 10
 
-PEDESTRIAN_MIN_SPEED = 0.3
+PEDESTRIAN_MIN_SPEED = 0.5
 THRESHOLD = 17
 
 # EGO BEHAVIOR: Follow lane and brake when reaches threshold distance to obstacle

--- a/examples/carla/Carla_Challenge/carlaChallenge4.scenic
+++ b/examples/carla/Carla_Challenge/carlaChallenge4.scenic
@@ -12,7 +12,8 @@ model scenic.simulators.carla.model
 
 ## CONSTANTS
 EGO_MODEL = "vehicle.lincoln.mkz2017"
-THROTTLE_ACTION = 1.0
+BICYCLE_MIN_SPEED = 1
+THRESHOLD = 15
 BRAKE_ACTION = 1.0
 SAFETY_DISTANCE = 10
 
@@ -23,10 +24,9 @@ behavior EgoBehavior(trajectory):
     interrupt when withinDistanceToObjsInLane(self, SAFETY_DISTANCE):
         take SetBrakeAction(BRAKE_ACTION)
 
-behavior BicycleBehavior(throttle):
-    while (distance from ego to self) > 15:
-        wait
-    do ConstantThrottleBehavior(throttle) for 15 seconds
+behavior BicycleBehavior(speed=3, threshold=15):
+    do CrossingBehavior(ego, speed, threshold)
+    do EmptyBehavior() for 3 seconds
     terminate
 
 ## GEOMETRY
@@ -45,7 +45,7 @@ spotBicycle = OrientedPoint in maneuver.endLane.centerline,
     facing roadDirection
 bicycle = Bicycle at spotBicycle offset by 3.5@0,
     with heading 90 deg relative to spotBicycle.heading,
-    with behavior BicycleBehavior(THROTTLE_ACTION),
+    with behavior BicycleBehavior(BICYCLE_MIN_SPEED, THRESHOLD),
     with regionContainedIn None
 
 require (distance from ego to intersec) < 25 and (distance from ego to intersec) > 10

--- a/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
@@ -15,17 +15,13 @@ EGO_MODEL = "vehicle.lincoln.mkz2017"
 EGO_SPEED = 10
 
 PEDESTRIAN_MIN_SPEED = 0.3
-
 THRESHOLD = 17
 
-behavior PedestrianBehavior(min_speed=1):
+behavior PedestrianBehavior(min_speed=1, threshold=10):
     while (ego.speed <= 0.1):
         wait
 
-    while (distance from self to ego) > THRESHOLD:
-        wait
-
-    do CrossingActorSpeedControl(ego, min_speed)
+    do CrossingBehavior(ego, min_speed, threshold)
 
 ## DEFINING SPATIAL RELATIONS
 # Please refer to scenic/domains/driving/roads.py how to access detailed road infrastructure
@@ -40,7 +36,7 @@ vending_spot = OrientedPoint following roadDirection from spot for -3
 pedestrian = Pedestrian right of spot by 3,
     with heading 90 deg relative to spot.heading,
     with regionContainedIn None,
-    with behavior PedestrianBehavior(PEDESTRIAN_MIN_SPEED)
+    with behavior PedestrianBehavior(PEDESTRIAN_MIN_SPEED, THRESHOLD)
 
 vending_machine = VendingMachine right of vending_spot by 3,
     with heading -90 deg relative to vending_spot.heading,

--- a/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
@@ -14,7 +14,7 @@ model scenic.simulators.carla.model
 EGO_MODEL = "vehicle.lincoln.mkz2017"
 EGO_SPEED = 10
 
-PEDESTRIAN_MIN_SPEED = 0.3
+PEDESTRIAN_MIN_SPEED = 0.5
 THRESHOLD = 17
 
 behavior PedestrianBehavior(min_speed=1, threshold=10):

--- a/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
+++ b/examples/carla/manual_control/carlaChallenge3_dynamic.scenic
@@ -14,11 +14,11 @@ model scenic.simulators.carla.model
 EGO_MODEL = "vehicle.lincoln.mkz2017"
 EGO_SPEED = 10
 
-PEDESTRIAN_SPEED = 5
+PEDESTRIAN_MIN_SPEED = 0.3
 
-THRESHOLD = 15
+THRESHOLD = 17
 
-behavior PedestrianBehavior(speed=3):
+behavior PedestrianBehavior(min_speed=1):
     while (ego.speed <= 0.1):
         wait
 
@@ -26,7 +26,7 @@ behavior PedestrianBehavior(speed=3):
         wait
 
     take SetWalkingDirectionAction(0)
-    take SetWalkingSpeedAction(speed)
+    do CrossingActorSpeedControl(ego, min_speed)
 
 ## DEFINING SPATIAL RELATIONS
 # Please refer to scenic/domains/driving/roads.py how to access detailed road infrastructure
@@ -41,7 +41,7 @@ vending_spot = OrientedPoint following roadDirection from spot for -3
 pedestrian = Pedestrian right of spot by 3,
     with heading 90 deg relative to spot.heading,
     with regionContainedIn None,
-    with behavior PedestrianBehavior(PEDESTRIAN_SPEED)
+    with behavior PedestrianBehavior(PEDESTRIAN_MIN_SPEED)
 
 vending_machine = VendingMachine right of vending_spot by 3,
     with heading -90 deg relative to vending_spot.heading,

--- a/examples/carla/manual_control/carlaChallenge4.scenic
+++ b/examples/carla/manual_control/carlaChallenge4.scenic
@@ -12,14 +12,12 @@ model scenic.simulators.carla.model
 
 ## CONSTANTS
 EGO_MODEL = "vehicle.lincoln.mkz2017"
-THROTTLE_ACTION = 1.0
-BRAKE_ACTION = 1.0
-SAFETY_DISTANCE = 10
+BICYCLE_MIN_SPEED = 1
+THRESHOLD = 15
 
-behavior BicycleBehavior(throttle):
-    while (distance from ego to self) > 15:
-        wait
-    do ConstantThrottleBehavior(throttle) for 15 seconds
+behavior BicycleBehavior(speed=3, threshold=15):
+    do CrossingBehavior(ego, speed, threshold)
+    do EmptyBehavior() for 3 seconds
     terminate
 
 ## GEOMETRY
@@ -38,7 +36,7 @@ spotBicycle = OrientedPoint in maneuver.endLane.centerline,
     facing roadDirection
 bicycle = Bicycle at spotBicycle offset by 3.5@0,
     with heading 90 deg relative to spotBicycle.heading,
-    with behavior BicycleBehavior(THROTTLE_ACTION),
+    with behavior BicycleBehavior(BICYCLE_MIN_SPEED, THRESHOLD),
     with regionContainedIn None
 
 require (distance from ego to intersec) < 25 and (distance from ego to intersec) > 10

--- a/src/scenic/domains/driving/behaviors.scenic
+++ b/src/scenic/domains/driving/behaviors.scenic
@@ -435,3 +435,7 @@ behavior CrossingBehavior(reference_actor, min_speed=1, threshold=10, final_spee
     elif isinstance(self, _model.Steers):
         take SetSpeedAction(final_speed)
 
+behavior EmptyBehavior():
+
+    while True:
+        wait

--- a/src/scenic/domains/driving/behaviors.scenic
+++ b/src/scenic/domains/driving/behaviors.scenic
@@ -392,3 +392,22 @@ behavior LaneChangeBehavior(laneSectionToSwitch, is_oppositeTraffic=False, targe
 
         take RegulatedControlAction(throttle, current_steer_angle, past_steer_angle)
         past_steer_angle = current_steer_angle
+
+
+behavior CrossingActorSpeedControl(reference_actor, min_speed=1):
+
+    while True:
+        distance_vec = self.position - reference_actor.position
+        rotated_vec = distance_vec.rotatedBy(-reference_actor.heading)
+
+        ref_dist = rotated_vec.y
+        actor_dist = rotated_vec.x
+
+        ref_speed = reference_actor.speed
+        ref_time = ref_speed / ref_dist
+
+        actor_speed = actor_dist * ref_time
+        if actor_speed < min_speed:
+            actor_speed = min_speed
+
+        take SetWalkingSpeedAction(actor_speed)

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -9,28 +9,3 @@ except ModuleNotFoundError:
 behavior WalkForwardBehavior():
 	while True:
 		take SetSpeedAction(0.5)
-
-behavior CrossingActorSpeedControl(reference_actor, min_speed=1):
-
-    while True:
-        distance_vec = self.position - reference_actor.position
-        rotated_vec = distance_vec.rotatedBy(-reference_actor.heading)
-
-        ref_dist = rotated_vec.y
-        actor_dist = rotated_vec.x
-
-        ref_speed = reference_actor.speed
-        ref_time = ref_speed / ref_dist
-
-        actor_speed = actor_dist * ref_time
-        if actor_speed < min_speed:
-            actor_speed = min_speed
-
-        print("---------------")
-        print("Reference Dist: ", ref_dist)
-        print("Actor Dist: ", actor_dist)
-        print("Reference Speed: ", ref_speed)
-        print("Reference Time: ", ref_time)
-        print("Actor Speed: ", actor_speed)
-
-        take SetWalkingSpeedAction(actor_speed)

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -9,3 +9,28 @@ except ModuleNotFoundError:
 behavior WalkForwardBehavior():
 	while True:
 		take SetSpeedAction(0.5)
+
+behavior CrossingActorSpeedControl(reference_actor, min_speed=1):
+
+    while True:
+        distance_vec = self.position - reference_actor.position
+        rotated_vec = distance_vec.rotatedBy(-reference_actor.heading)
+
+        ref_dist = rotated_vec.y
+        actor_dist = rotated_vec.x
+
+        ref_speed = reference_actor.speed
+        ref_time = ref_speed / ref_dist
+
+        actor_speed = actor_dist * ref_time
+        if actor_speed < min_speed:
+            actor_speed = min_speed
+
+        print("---------------")
+        print("Reference Dist: ", ref_dist)
+        print("Actor Dist: ", actor_dist)
+        print("Reference Speed: ", ref_speed)
+        print("Reference Time: ", ref_time)
+        print("Actor Speed: ", actor_speed)
+
+        take SetWalkingSpeedAction(actor_speed)

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -1,6 +1,7 @@
 
 from scenic.domains.driving.behaviors import *	# use common driving behaviors
 
+
 try:
     from scenic.simulators.carla.actions import *
 except ModuleNotFoundError:
@@ -8,10 +9,6 @@ except ModuleNotFoundError:
 
 behavior AutopilotBehavior():
 	take SetAutopilotAction(True)
-
-behavior WalkForwardBehavior(speed=0.5):
-	take SetWalkingDirectionAction(0)
-	take SetWalkingSpeedAction(speed)
 
 behavior WalkBehavior(maxSpeed=1.4):
 	take SetWalkAction(True, maxSpeed)

--- a/src/scenic/simulators/carla/behaviors.scenic
+++ b/src/scenic/simulators/carla/behaviors.scenic
@@ -1,7 +1,6 @@
 
 from scenic.domains.driving.behaviors import *	# use common driving behaviors
 
-
 try:
     from scenic.simulators.carla.actions import *
 except ModuleNotFoundError:

--- a/src/scenic/simulators/carla/model.scenic
+++ b/src/scenic/simulators/carla/model.scenic
@@ -83,9 +83,7 @@ class CarlaActor(DrivingObject):
         self.carlaActor.set_location(utils.scenicToCarlaLocation(pos, elevation))
 
     def setVelocity(self, vel):
-        carla_vel = utils.scenicToCarlaVector3D(*vel)
-        carla_vel.y = -carla_vel.y # Change to CARLA's coordinate system
-        self.carlaActor.set_target_velocity(carla_vel)
+        self.carlaActor.set_target_velocity(utils.scenicToCarlaVector3D(*vel))
 
 
 class Vehicle(Vehicle, CarlaActor, Steers):
@@ -139,8 +137,9 @@ class Pedestrian(Pedestrian, CarlaActor, Walks):
     carlaController: None
 
     def setWalkingDirection(self, heading):
-        forward = self.carlaActor.get_transform().get_forward_vector()
-        direction = Vector(forward.x, forward.y).rotatedBy(heading)
+        # TODO: forward calculus takes into account the diffeerence in references. Use a generic function to calculate it
+        forward = Vector(-sin(self.heading), cos(self.heading))
+        direction = forward.rotatedBy(heading)
         zComp = self.control.direction.z
         self.control.direction = utils.scenicToCarlaVector3D(*direction, zComp)
 

--- a/src/scenic/simulators/carla/model.scenic
+++ b/src/scenic/simulators/carla/model.scenic
@@ -83,7 +83,9 @@ class CarlaActor(DrivingObject):
         self.carlaActor.set_location(utils.scenicToCarlaLocation(pos, elevation))
 
     def setVelocity(self, vel):
-        self.carlaActor.set_target_velocity(utils.scenicToCarlaVector3D(*vel))
+        carla_vel = utils.scenicToCarlaVector3D(*vel)
+        carla_vel.y = -carla_vel.y # Change to CARLA's coordinate system
+        self.carlaActor.set_target_velocity(carla_vel)
 
 
 class Vehicle(Vehicle, CarlaActor, Steers):

--- a/src/scenic/simulators/carla/utils/utils.py
+++ b/src/scenic/simulators/carla/utils/utils.py
@@ -15,7 +15,7 @@ def snapToGround(world, location):
 def scenicToCarlaVector3D(x, y, z=0.0):
 	# NOTE: Used for velocity, acceleration; superclass of carla.Location
 	z = 0.0 if z is None else z
-	return carla.Vector3D(x, y, z)
+	return carla.Vector3D(x, -y, z)
 
 
 def scenicToCarlaLocation(pos, z=None, world=None):


### PR DESCRIPTION
- Added new ***CrossingBehavior*** behavior, which dynamically changes the speed of an actor (which theoretically is perpendicular to the road), to force a *reference_actor* to break. This behavior ends when the reference actor surpasses the crossing actor.
- Moved ***WalkForwardBehavior*** from *carla* to * driving* file
- Fixed ***utils.scenicToCarlaVector3D*** function to take into account the reference change
- Added a termination to ***carlaChallenge3_dynamic.scenic***